### PR TITLE
Switch off AutoReconnect on gracefully disconnect

### DIFF
--- a/AsyncTcpClient/AsyncTcpClient.cs
+++ b/AsyncTcpClient/AsyncTcpClient.cs
@@ -234,11 +234,16 @@ namespace Unclassified.Net
 							Message?.Invoke(this, new AsyncTcpEventArgs("Connection reset remotely", ex));
 							readLength = -2;
 						}
+						catch(Exception ex)
+						{
+							Message?.Invoke(this, new AsyncTcpEventArgs("Read from stream failed", ex));
+							readLength = -3;
+						}
 						if (readLength <= 0)
 						{
 							if (readLength == 0)
 							{
-								Message?.Invoke(this, new AsyncTcpEventArgs("Connection closed remotely"));
+								Message?.Invoke(this, new AsyncTcpEventArgs("Connection closed gracefully"));
 							}
 							closedTcs.TrySetResult(true);
 							OnClosed(readLength != -1);
@@ -263,13 +268,26 @@ namespace Unclassified.Net
 		}
 
 		/// <summary>
-		/// Closes the socket connection normally. This does not release the resources used by the
+		/// Closes the socket connection normally. Switch off AutoReconnect. This does not release the resources used by the
 		/// <see cref="AsyncTcpClient"/>.
 		/// </summary>
 		public void Disconnect()
 		{
+			AutoReconnect = false;
 			tcpClient.Client.Disconnect(false);
 		}
+
+
+		/// <summary>
+		/// Closes the socket connection normally and try to connect again. This does not release the resources used by the
+		/// <see cref="AsyncTcpClient"/>.
+		/// </summary>
+		public void DisconnectAndReconnect()
+		{
+			AutoReconnect = true;
+			tcpClient.Client.Disconnect(false);
+		}
+
 
 		/// <summary>
 		/// Releases the managed and unmanaged resources used by the <see cref="AsyncTcpClient"/>.

--- a/AsyncTcpClientDemo/Program.cs
+++ b/AsyncTcpClientDemo/Program.cs
@@ -94,9 +94,9 @@ namespace AsyncTcpClientDemo
 
 			var client = new AsyncTcpClient
 			{
-				IPAddress = IPAddress.IPv6Loopback,
+				IPAddress = IPAddress.Loopback,
 				Port = port,
-				//AutoReconnect = true,
+				AutoReconnect = true,
 				ConnectedCallback = async (c, isReconnected) =>
 				{
 					await c.WaitAsync();   // Wait for server banner
@@ -143,19 +143,29 @@ namespace AsyncTcpClientDemo
 					byte[] bytes = c.ByteBuffer.Dequeue(count);
 					string message = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
 					Console.WriteLine("Client: received: " + message);
+
+					if (message == "close")
+						c.Disconnect();
+
 					return Task.CompletedTask;
 				}
 			};
 			client.Message += (s, a) => Console.WriteLine("Client: " + a.Message);
 			var clientTask = client.RunAsync();
 
-			await Task.Delay(10 * 1000);
-			Console.WriteLine("Program: stopping server");
-			server.Stop(true);
-			await serverTask;
 
-			client.Dispose();
+			// Setup 1
+			//await Task.Delay(10 * 1000);
+			//Console.WriteLine("Program: stopping server");
+			//server.Stop(true);
+			//await serverTask;
+			//client.Disconnect();
+			//await clientTask;
+
+
+			// Setup 2
 			await clientTask;
+			client.Dispose();
 		}
 	}
 }


### PR DESCRIPTION
Client would like to immediately reconnect even if explicit disconnect is wished. Solved by add a second Disconnect method
- Disconnect method set AutoReconnect to false
- Added DisconnectAndReconnect method

Exception from ReadAsync when client was disposed
- Catch exception if stream object is null after it client was disposed

Minor changes on demo (no pull needed) ;